### PR TITLE
Skip non-existing status files in /status_poll

### DIFF
--- a/greendots-server/main.go
+++ b/greendots-server/main.go
@@ -560,6 +560,10 @@ func runStatusPollHandler(w http.ResponseWriter, r *http.Request) {
 			statusPath := filepath.Join(config.ProjectsDir, project, run, fmt.Sprintf("status.%d.jsonl", i))
 			stat, err := os.Stat(statusPath)
 			if err != nil {
+				// If the file doesn't exist, skip it and move on to the next file.
+				if os.IsNotExist(err) {
+					continue;
+				}
 				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 				return
 			}


### PR DESCRIPTION
Before this change, /status_poll returned 404 until all workers had started working and have created their status.%d.jsonl files.

This behaviour was problematic because we wanted to add workers which start delayed, and the matrix didn't show live updates until the last worker had started.